### PR TITLE
Fix: No need to ignore vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/vendor
 composer.phar
 composer.lock
 .DS_Store


### PR DESCRIPTION
This PR

* [x] removes the `vendor` directory from `.gitignore` as actually, there are no dependencies which could be installed with composer