### PR TITLE
Fix: Remove unused stability flags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,5 @@
         "psr-0": {
             "Intouch\\Newrelic": "src/"
         }
-    },
-    "minimum-stability": "dev"
+    }
 }


### PR DESCRIPTION
This PR

* [x] removes `minimum-stability` configuration, which has no effect since we don't have any dependencies anyway