### PR TITLE
Enhancement: Add tests, run them on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+vendor/
 composer.phar
 composer.lock
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: php
+
+sudo: false
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7
+  - hhvm
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+before_install:
+  - composer self-update
+  - composer validate
+
+install:
+  - composer install --prefer-dist
+
+script:
+  - vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![githalytics.com alpha](https://cruel-carlota.pagodabox.com/2b89df0c6f1ce6e999edfe2a60946481 "githalytics.com")](http://githalytics.com/In-Touch/newrelic)
+[![Build Status](https://travis-ci.org/In-Touch/newrelic.svg?branch=master)](https://travis-ci.org/In-Touch/newrelic)
 
 # NewRelic PHP Agent API Wrapper
 

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,12 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8"
+    },
     "autoload": {
         "psr-0": {
             "Intouch\\Newrelic": "src/"
         }
-    },
-    "minimum-stability": "dev"
+    }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,23 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    verbose="true"
+>
+    <testsuites>
+        <testsuite name="Tests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/NewrelicTest.php
+++ b/tests/NewrelicTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Intouch\Newrelic\Test;
+
+use Intouch\Newrelic\Newrelic;
+
+class NewrelicTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIsExtensionLoaded()
+    {
+        $agent = new Newrelic();
+
+        $this->assertAttributeSame($this->isExtensionLoaded(), 'installed', $agent);
+    }
+
+    public function testConstructorThrowsRuntimeExceptionIfThrowIsTrueAndExtensionNotLoaded()
+    {
+        if ($this->isExtensionLoaded() === true) {
+            $this->markTestSkipped('Can not run test when newrelic extension is loaded');
+        }
+
+        $this->setExpectedException('RuntimeException', 'NewRelic PHP Agent does not appear to be installed');
+
+        new Newrelic(true);
+    }
+
+    public function testMethodsExist()
+    {
+        if ($this->isExtensionLoaded() === true) {
+            $this->markTestSkipped('Can not run test when newrelic extension is loaded');
+        }
+
+        $agent = new Newrelic();
+
+        $this->assertFalse($agent->addCustomParameter('foo', 'bar'));
+        $this->assertFalse($agent->addCustomTracer('foo'));
+        $this->assertFalse($agent->backgroundJob(false));
+        $this->assertFalse($agent->captureParams(false));
+        $this->assertFalse($agent->customMetric('foo', 9000));
+        $this->assertFalse($agent->disableAutoRUM());
+        $this->assertFalse($agent->endOfTransaction());
+        $this->assertFalse($agent->endTransaction());
+        $this->assertFalse($agent->getBrowserTimingFooter(false));
+        $this->assertFalse($agent->getBrowserTimingHeader(false));
+        $this->assertFalse($agent->ignoreApdex());
+        $this->assertFalse($agent->ignoreTransaction());
+        $this->assertFalse($agent->nameTransaction('foo'));
+        $this->assertFalse($agent->noticeError('foo', 'bar'));
+        $this->assertFalse($agent->setAppName('foo', 'bar', false));
+        $this->assertFalse($agent->setUserAttributes('foo', 'bar', 'baz'));
+        $this->assertFalse($agent->startTransaction('foo', 'bar'));
+    }
+
+    /**
+     * @return bool
+     */
+    private function isExtensionLoaded()
+    {
+        return extension_loaded('newrelic') && function_exists('newrelic_set_appname');
+    }
+}


### PR DESCRIPTION
This PR

* [x] requires `phpunit/phpunit` (and removes the `minimum-stability` flag)
* [x] adds a configuration for `phpunit`
* [x] adds coverage
* [x] adds a configuration for Travis (again)
* [x] adds a build status badge to `README.md` (and removes the broken badge)

:information_desk_person: This only requires to enable the build on Travis again.