### PR TITLE
Fix: Whitelist src directory in PHPUnit configuration

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,4 +20,9 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist>
+            <directory>src</directory>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
This PR

* [x] whitelists the `src` directory in `phpunit.xml`