### PR TITLE
Enhancement: Use handlers to make actual calls

### DIFF
--- a/src/Intouch/Newrelic/Handler/DefaultHandler.php
+++ b/src/Intouch/Newrelic/Handler/DefaultHandler.php
@@ -2,14 +2,8 @@
 
 namespace Intouch\Newrelic\Handler;
 
-class DefaultHandler
+class DefaultHandler implements Handler
 {
-    /**
-     * @param string $functionName
-     * @param array $arguments
-     *
-     * @return mixed
-     */
     public function handle($functionName, array $arguments = array())
     {
         return call_user_func_array($functionName, $arguments);

--- a/src/Intouch/Newrelic/Handler/DefaultHandler.php
+++ b/src/Intouch/Newrelic/Handler/DefaultHandler.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Intouch\Newrelic\Handler;
+
+class DefaultHandler
+{
+    /**
+     * @param string $functionName
+     * @param array $arguments
+     *
+     * @return mixed
+     */
+    public function handle($functionName, array $arguments = array())
+    {
+        return call_user_func_array($functionName, $arguments);
+    }
+}

--- a/src/Intouch/Newrelic/Handler/Handler.php
+++ b/src/Intouch/Newrelic/Handler/Handler.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Intouch\Newrelic\Handler;
+
+interface Handler
+{
+    /**
+     * @param string $functionName
+     * @param array $arguments
+     *
+     * @return mixed
+     */
+    public function handle($functionName, array $arguments = array());
+}

--- a/src/Intouch/Newrelic/Handler/NullHandler.php
+++ b/src/Intouch/Newrelic/Handler/NullHandler.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Intouch\Newrelic\Handler;
+
+class NullHandler implements Handler
+{
+    public function handle($functionName, array $arguments = array())
+    {
+        return false;
+    }
+}

--- a/src/Intouch/Newrelic/Newrelic.php
+++ b/src/Intouch/Newrelic/Newrelic.php
@@ -18,6 +18,7 @@ namespace Intouch\Newrelic;
 
 use Intouch\Newrelic\Handler\DefaultHandler;
 use Intouch\Newrelic\Handler\Handler;
+use Intouch\Newrelic\Handler\NullHandler;
 
 /**
  * Wrapper class for the NewRelic PHP Agent API methods.
@@ -55,7 +56,11 @@ class Newrelic
             throw new \RuntimeException('NewRelic PHP Agent does not appear to be installed');
         }
 
-        $this->handler = $handler ? $handler : new DefaultHandler();
+        if ($handler === null) {
+            $handler = $this->installed ? new DefaultHandler() : new NullHandler();
+        }
+
+        $this->handler = $handler;
     }
 
     /**

--- a/src/Intouch/Newrelic/Newrelic.php
+++ b/src/Intouch/Newrelic/Newrelic.php
@@ -42,10 +42,11 @@ class Newrelic
      * NewRelic PHP agent methods are not found.
      *
      * @param bool $throw
+     * @param DefaultHandler $handler
      *
      * @throws \RuntimeException
      */
-    public function __construct($throw = false)
+    public function __construct($throw = false, DefaultHandler $handler = null)
     {
         $this->installed = extension_loaded('newrelic') && function_exists('newrelic_set_appname');
 
@@ -53,7 +54,7 @@ class Newrelic
             throw new \RuntimeException('NewRelic PHP Agent does not appear to be installed');
         }
 
-        $this->handler = new DefaultHandler();
+        $this->handler = $handler ? $handler : new DefaultHandler();
     }
 
     /**

--- a/src/Intouch/Newrelic/Newrelic.php
+++ b/src/Intouch/Newrelic/Newrelic.php
@@ -16,6 +16,8 @@
  */
 namespace Intouch\Newrelic;
 
+use Intouch\Newrelic\Handler\DefaultHandler;
+
 /**
  * Wrapper class for the NewRelic PHP Agent API methods.
  *
@@ -29,6 +31,11 @@ class Newrelic
      * @var bool
      */
     protected $installed;
+
+    /**
+     * @var DefaultHandler
+     */
+    private $handler;
 
     /**
      * Allows pass-through if NewRelic is not installed (default) or optionally throws a runtime exception is the
@@ -45,6 +52,8 @@ class Newrelic
         if ($throw && !$this->installed) {
             throw new \RuntimeException('NewRelic PHP Agent does not appear to be installed');
         }
+
+        $this->handler = new DefaultHandler();
     }
 
     /**
@@ -353,6 +362,6 @@ class Newrelic
             return false;
         }
 
-        return call_user_func_array($method, $params);
+        return $this->handler->handle($method, $params);
     }
 }

--- a/src/Intouch/Newrelic/Newrelic.php
+++ b/src/Intouch/Newrelic/Newrelic.php
@@ -365,10 +365,6 @@ class Newrelic
      */
     protected function call($method, array $params = array())
     {
-        if (!$this->installed) {
-            return false;
-        }
-
         return $this->handler->handle($method, $params);
     }
 }

--- a/src/Intouch/Newrelic/Newrelic.php
+++ b/src/Intouch/Newrelic/Newrelic.php
@@ -17,6 +17,7 @@
 namespace Intouch\Newrelic;
 
 use Intouch\Newrelic\Handler\DefaultHandler;
+use Intouch\Newrelic\Handler\Handler;
 
 /**
  * Wrapper class for the NewRelic PHP Agent API methods.
@@ -33,7 +34,7 @@ class Newrelic
     protected $installed;
 
     /**
-     * @var DefaultHandler
+     * @var Handler
      */
     private $handler;
 
@@ -42,11 +43,11 @@ class Newrelic
      * NewRelic PHP agent methods are not found.
      *
      * @param bool $throw
-     * @param DefaultHandler $handler
+     * @param Handler $handler
      *
      * @throws \RuntimeException
      */
-    public function __construct($throw = false, DefaultHandler $handler = null)
+    public function __construct($throw = false, Handler $handler = null)
     {
         $this->installed = extension_loaded('newrelic') && function_exists('newrelic_set_appname');
 

--- a/tests/Handler/DefaultHandlerTest.php
+++ b/tests/Handler/DefaultHandlerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Intouch\Newrelic\Test\Handler;
+
+use Intouch\Newrelic\Handler\DefaultHandler;
+
+class DefaultHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHandleCallsFunctionWithArguments()
+    {
+        $functionName = 'strpos';
+        $arguments = array(
+            'foobarbaz',
+            'bar',
+            0
+        );
+
+        $handler = new DefaultHandler();
+
+        $expected = call_user_func_array($functionName, $arguments);
+
+        $this->assertSame($expected, $handler->handle($functionName, $arguments));
+    }
+}

--- a/tests/Handler/DefaultHandlerTest.php
+++ b/tests/Handler/DefaultHandlerTest.php
@@ -6,6 +6,12 @@ use Intouch\Newrelic\Handler\DefaultHandler;
 
 class DefaultHandlerTest extends \PHPUnit_Framework_TestCase
 {
+    public function testImplementsInterface()
+    {
+        $handler = new DefaultHandler();
+
+        $this->assertInstanceOf('Intouch\Newrelic\Handler\Handler', $handler);
+    }
     public function testHandleCallsFunctionWithArguments()
     {
         $functionName = 'strpos';

--- a/tests/Handler/NullHandlerTest.php
+++ b/tests/Handler/NullHandlerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Intouch\Newrelic\Test\Handler;
+
+use Intouch\Newrelic\Handler\NullHandler;
+
+class NullHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testImplementsInterface()
+    {
+        $handler = new NullHandler();
+
+        $this->assertInstanceOf('Intouch\Newrelic\Handler\Handler', $handler);
+    }
+
+    public function testHandleReturnsFalse()
+    {
+        $functionName = 'strpos';
+        $arguments = array(
+            'foobarbaz',
+            'bar',
+            0
+        );
+
+        $handler = new NullHandler();
+
+        $this->assertFalse($handler->handle($functionName, $arguments));
+    }
+}

--- a/tests/NewrelicTest.php
+++ b/tests/NewrelicTest.php
@@ -6,6 +6,13 @@ use Intouch\Newrelic\Newrelic;
 
 class NewrelicTest extends \PHPUnit_Framework_TestCase
 {
+    public function testConstructCreatesDefaultHandler()
+    {
+        $agent = new Newrelic();
+
+        $this->assertAttributeInstanceOf('Intouch\Newrelic\Handler\DefaultHandler', 'handler', $agent);
+    }
+
     public function testIsExtensionLoaded()
     {
         $agent = new Newrelic();

--- a/tests/NewrelicTest.php
+++ b/tests/NewrelicTest.php
@@ -45,31 +45,334 @@ class NewrelicTest extends \PHPUnit_Framework_TestCase
         new Newrelic(true);
     }
 
-    public function testMethodsExist()
+    public function testAddCustomParameter()
     {
-        if ($this->isExtensionLoaded() === true) {
-            $this->markTestSkipped('Can not run test when newrelic extension is loaded');
-        }
+        $key = 'foo';
+        $value = 'bar';
 
-        $agent = new Newrelic();
+        $result = true;
 
-        $this->assertFalse($agent->addCustomParameter('foo', 'bar'));
-        $this->assertFalse($agent->addCustomTracer('foo'));
-        $this->assertFalse($agent->backgroundJob(false));
-        $this->assertFalse($agent->captureParams(false));
-        $this->assertFalse($agent->customMetric('foo', 9000));
-        $this->assertFalse($agent->disableAutoRUM());
-        $this->assertFalse($agent->endOfTransaction());
-        $this->assertFalse($agent->endTransaction());
-        $this->assertFalse($agent->getBrowserTimingFooter(false));
-        $this->assertFalse($agent->getBrowserTimingHeader(false));
-        $this->assertFalse($agent->ignoreApdex());
-        $this->assertFalse($agent->ignoreTransaction());
-        $this->assertFalse($agent->nameTransaction('foo'));
-        $this->assertFalse($agent->noticeError('foo', 'bar'));
-        $this->assertFalse($agent->setAppName('foo', 'bar', false));
-        $this->assertFalse($agent->setUserAttributes('foo', 'bar', 'baz'));
-        $this->assertFalse($agent->startTransaction('foo', 'bar'));
+        $handler = $this->getHandlerSpy(
+            'newrelic_add_custom_parameter',
+            array(
+                $key,
+                $value
+            ),
+            $result
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertSame($result, $agent->addCustomParameter($key, $value));
+    }
+
+    public function testAddCustomTracer()
+    {
+        $functionName = 'bar';
+
+        $result = true;
+
+        $handler = $this->getHandlerSpy(
+            'newrelic_add_custom_tracer',
+            array(
+                $functionName
+            ),
+            $result
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertSame($result, $agent->addCustomTracer($functionName));
+    }
+
+    public function testBackgroundJob()
+    {
+        $flag = true;
+
+        $result = true;
+
+        $handler = $this->getHandlerSpy(
+            'newrelic_background_job',
+            array(
+                $flag
+            ),
+            $result
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertSame($result, $agent->backgroundJob($flag));
+    }
+
+    public function testCaptureParams()
+    {
+        $enable = true;
+
+        $result = true;
+
+        $handler = $this->getHandlerSpy(
+            'newrelic_capture_params',
+            array(
+                $enable
+            ),
+            $result
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertSame($result, $agent->captureParams($enable));
+    }
+
+    public function testCustomMetric()
+    {
+        $name = 'foo';
+        $value = 9000;
+
+        $result = true;
+
+        $handler = $this->getHandlerSpy(
+            'newrelic_custom_metric',
+            array(
+                $name,
+                $value
+            ),
+            $result
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertSame($result, $agent->customMetric($name, $value));
+    }
+
+    public function testDisableAutoRUM()
+    {
+        $result = true;
+
+        $handler = $this->getHandlerSpy(
+            'newrelic_disable_autorum',
+            array(),
+            $result
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertSame($result, $agent->disableAutoRUM());
+    }
+
+    public function testEndOfTransaction()
+    {
+        $handler = $this->getHandlerSpy(
+            'newrelic_end_of_transaction',
+            array()
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertNull($agent->endOfTransaction());
+    }
+
+    public function testEndTransaction()
+    {
+        $ignore = false;
+
+        $handler = $this->getHandlerSpy(
+            'newrelic_end_transaction',
+            array(
+                $ignore,
+            )
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertNull($agent->endTransaction($ignore));
+    }
+
+    public function testGetBrowserTimingFooter()
+    {
+        $includeTags = false;
+
+        $result = '<p>Foo</p>';
+
+        $handler = $this->getHandlerSpy(
+            'newrelic_get_browser_timing_footer',
+            array(
+                $includeTags,
+            ),
+            $result
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertSame($result, $agent->getBrowserTimingFooter($includeTags));
+    }
+
+    public function testGetBrowserTimingHeader()
+    {
+        $includeTags = false;
+
+        $result = '<p>Foo</p>';
+
+        $handler = $this->getHandlerSpy(
+            'newrelic_get_browser_timing_header',
+            array(
+                $includeTags,
+            ),
+            $result
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertSame($result, $agent->getBrowserTimingHeader($includeTags));
+    }
+
+    public function testIgnoreApdex()
+    {
+        $handler = $this->getHandlerSpy(
+            'newrelic_ignore_apdex',
+            array()
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertNull($agent->ignoreApdex());
+    }
+
+    public function testIgnoreTransaction()
+    {
+        $handler = $this->getHandlerSpy(
+            'newrelic_ignore_transaction',
+            array()
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertNull($agent->ignoreTransaction());
+    }
+
+    public function testNameTransaction()
+    {
+        $name = 'foo';
+
+        $result = true;
+
+        $handler = $this->getHandlerSpy(
+            'newrelic_name_transaction',
+            array(
+                $name,
+            ),
+            $result
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertSame($result, $agent->nameTransaction($name));
+    }
+
+    public function testNoticeError()
+    {
+        $message = 'foo';
+        $exception = new \InvalidArgumentException('bar');
+
+        $result = true;
+
+        $handler = $this->getHandlerSpy(
+            'newrelic_notice_error',
+            array(
+                $message,
+                $exception,
+            ),
+            $result
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertSame($result, $agent->noticeError($message, $exception));
+    }
+
+    public function testNoticeErrorWithoutException()
+    {
+        $message = 'foo';
+
+        $result = true;
+
+        $handler = $this->getHandlerSpy(
+            'newrelic_notice_error',
+            array(
+                $message,
+            ),
+            $result
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertSame($result, $agent->noticeError($message));
+    }
+
+    public function testSetAppName()
+    {
+        $name = 'foo';
+        $licence = 'bar9000';
+        $xmit = false;
+
+        $result = true;
+
+        $handler = $this->getHandlerSpy(
+            'newrelic_set_appname',
+            array(
+                $name,
+                $licence,
+                $xmit,
+            ),
+            $result
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertSame($result, $agent->setAppName($name, $licence, $xmit));
+    }
+
+    public function testSetUserAttributes()
+    {
+        $user = 'foo';
+        $account = 'bar';
+        $product = 'baz';
+
+        $result = true;
+
+        $handler = $this->getHandlerSpy(
+            'newrelic_set_user_attributes',
+            array(
+                $user,
+                $account,
+                $product,
+            ),
+            $result
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertSame($result, $agent->setUserAttributes($user, $account, $product));
+    }
+
+    public function testStartTransaction()
+    {
+        $name = 'foo';
+        $licence = 'bar9000';
+
+        $result = true;
+
+        $handler = $this->getHandlerSpy(
+            'newrelic_start_transaction',
+            array(
+                $name,
+                $licence,
+            ),
+            $result
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertSame($result, $agent->startTransaction($name, $licence));
     }
 
     /**
@@ -86,5 +389,28 @@ class NewrelicTest extends \PHPUnit_Framework_TestCase
     private function getHandlerMock()
     {
         return $this->getMockBuilder('Intouch\Newrelic\Handler\Handler')->getMock();
+    }
+
+    /**
+     * @param string $functionName
+     * @param array $arguments
+     * @param mixed $result
+     * @return Handler|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getHandlerSpy($functionName, array $arguments = array(), $result = null)
+    {
+        $handler = $this->getHandlerMock();
+
+        $handler
+            ->expects($this->once())
+            ->method('handle')
+            ->with(
+                $this->identicalTo($functionName),
+                $this->identicalTo($arguments)
+            )
+            ->willReturn($result)
+        ;
+
+        return $handler;
     }
 }

--- a/tests/NewrelicTest.php
+++ b/tests/NewrelicTest.php
@@ -6,11 +6,16 @@ use Intouch\Newrelic\Newrelic;
 
 class NewrelicTest extends \PHPUnit_Framework_TestCase
 {
-    public function testConstructCreatesDefaultHandler()
+    public function testConstructCreatesHandler()
     {
         $agent = new Newrelic();
 
-        $this->assertAttributeInstanceOf('Intouch\Newrelic\Handler\DefaultHandler', 'handler', $agent);
+        $class = 'Intouch\Newrelic\Handler\NullHandler';
+        if ($this->isExtensionLoaded()) {
+            $class = 'Intouch\Newrelic\Handler\DefaultHandler';
+        }
+
+        $this->assertAttributeInstanceOf($class, 'handler', $agent);
     }
 
     public function testConstructSetsHandler()

--- a/tests/NewrelicTest.php
+++ b/tests/NewrelicTest.php
@@ -13,6 +13,15 @@ class NewrelicTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeInstanceOf('Intouch\Newrelic\Handler\DefaultHandler', 'handler', $agent);
     }
 
+    public function testConstructSetsHandler()
+    {
+        $handler = $this->getDefaultHandlerMock();
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertAttributeSame($handler, 'handler', $agent);
+    }
+
     public function testIsExtensionLoaded()
     {
         $agent = new Newrelic();
@@ -64,5 +73,13 @@ class NewrelicTest extends \PHPUnit_Framework_TestCase
     private function isExtensionLoaded()
     {
         return extension_loaded('newrelic') && function_exists('newrelic_set_appname');
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|DefaultHandler
+     */
+    private function getDefaultHandlerMock()
+    {
+        return $this->getMockBuilder('Intouch\Newrelic\Handler\DefaultHandler')->getMock();
     }
 }

--- a/tests/NewrelicTest.php
+++ b/tests/NewrelicTest.php
@@ -15,7 +15,7 @@ class NewrelicTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructSetsHandler()
     {
-        $handler = $this->getDefaultHandlerMock();
+        $handler = $this->getHandlerMock();
 
         $agent = new Newrelic(false, $handler);
 
@@ -76,10 +76,10 @@ class NewrelicTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|DefaultHandler
+     * @return \PHPUnit_Framework_MockObject_MockObject|Handler
      */
-    private function getDefaultHandlerMock()
+    private function getHandlerMock()
     {
-        return $this->getMockBuilder('Intouch\Newrelic\Handler\DefaultHandler')->getMock();
+        return $this->getMockBuilder('Intouch\Newrelic\Handler\Handler')->getMock();
     }
 }


### PR DESCRIPTION
This PR

* [x] extracts a `DefaultHandler` from `Newrelic`
* [x] creates a `DefaultHandler` during construction of `Newrelic` and uses it to handle calls
* [x] allows to inject a `DefaultHandler` into `Newrelic`
* [x] extracts a `Handler` interface from `DefaultHandler` 
* [x] allows to inject an implementation of  `Handler` into `Newrelic`
* [x] implements a `NullHandler` which will do nothing and always return `false`
* [x] creates a `NullHandler` during construction of `Newrelic` if the extension is not loaded
* [x] removes a condition
* [x] asserts that the right functions are called

:information_desk_person: The idea behind extracting a handler is that we both want to assert that the right functions are called with the right arguments, as well as be able to use a different handler in environments where we don't want to send messages to the New Relic API even if the extension is installed (for example, in development, testing, and / or staging environments).
