### PR TITLE
Fix: Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/tests              export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/phpunit.xml        export-ignore


### PR DESCRIPTION
This PR
- [x] adds a `.gitattributes` file

:information_desk_person: This prevents exporting what will likely not be needed in dependent packages.
