### PR TITLE
Add support for distributed tracing

### DIFF
--- a/src/Handler/DefaultHandler.php
+++ b/src/Handler/DefaultHandler.php
@@ -4,8 +4,20 @@ namespace Intouch\Newrelic\Handler;
 
 class DefaultHandler implements Handler
 {
+    private $hasDistributedTracing;
+
+    public function __construct($hasDistributedTracing)
+    {
+        $this->hasDistributedTracing = $hasDistributedTracing;
+    }
+
     public function handle($functionName, array $arguments = array())
     {
         return call_user_func_array($functionName, $arguments);
+    }
+
+    public function isDistributedTracingEnabled()
+    {
+        return $this->hasDistributedTracing;
     }
 }

--- a/src/Handler/Handler.php
+++ b/src/Handler/Handler.php
@@ -11,4 +11,9 @@ interface Handler
      * @return mixed
      */
     public function handle($functionName, array $arguments = array());
+
+    /**
+     * @return bool
+     */
+    public function isDistributedTracingEnabled();
 }

--- a/src/Handler/NullHandler.php
+++ b/src/Handler/NullHandler.php
@@ -8,4 +8,9 @@ class NullHandler implements Handler
     {
         return false;
     }
+
+    public function isDistributedTracingEnabled()
+    {
+        return false;
+    }
 }

--- a/src/Newrelic.php
+++ b/src/Newrelic.php
@@ -57,7 +57,9 @@ class Newrelic
         }
 
         if ($handler === null) {
-            $handler = $this->installed ? new DefaultHandler() : new NullHandler();
+            $handler = $this->installed
+                ? new DefaultHandler(function_exists('newrelic_create_distributed_trace_payload'))
+                : new NullHandler();
         }
 
         $this->handler = $handler;
@@ -381,11 +383,15 @@ class Newrelic
      * Create a newrelic distributed trace payload.
      * {@link https://docs.newrelic.com/docs/agents/php-agent/features/distributed-tracing-php#manual}
      *
-     * @return newrelic\DistributedTracePayload
+     * @return newrelic\DistributedTracePayload|false
      */
     public function createDistributedTracePayload()
     {
-        return $this->call('newrelic_create_distributed_trace_payload');
+        if ($this->handler->isDistributedTracingEnabled()) {
+            return $this->call('newrelic_create_distributed_trace_payload');
+        }
+
+        return false;
     }
 
     /**
@@ -401,7 +407,11 @@ class Newrelic
      */
     public function acceptDistributedTracePayload($textPayload)
     {
-        return $this->call('newrelic_accept_distributed_trace_payload', array($textPayload));
+        if ($this->handler->isDistributedTracingEnabled()) {
+            return $this->call('newrelic_accept_distributed_trace_payload', array($textPayload));
+        }
+
+        return false;
     }
 
     /**
@@ -417,7 +427,11 @@ class Newrelic
      */
     public function acceptDistributedTracePayloadHttpSafe($httpSafePayload)
     {
-        return $this->call('newrelic_accept_distributed_trace_payload_httpsafe', array($httpSafePayload));
+        if ($this->handler->isDistributedTracingEnabled()) {
+            return $this->call('newrelic_accept_distributed_trace_payload_httpsafe', array($httpSafePayload));
+        }
+
+        return false;
     }
 
     /**

--- a/src/Newrelic.php
+++ b/src/Newrelic.php
@@ -378,6 +378,49 @@ class Newrelic
     }
 
     /**
+     * Create a newrelic distributed trace payload.
+     * {@link https://docs.newrelic.com/docs/agents/php-agent/features/distributed-tracing-php#manual}
+     *
+     * @return newrelic\DistributedTracePayload
+     */
+    public function createDistributedTracePayload()
+    {
+        return $this->call('newrelic_create_distributed_trace_payload');
+    }
+
+    /**
+     * Accept a distributed trace payload.
+     *
+     * Generate a payload using:
+     * $payload = newrelic_create_distributed_trace_payload();
+     * $textPayload = $payload->Text();
+     *
+     * @param string $textPayload
+     *
+     * @return bool
+     */
+    public function acceptDistributedTracePayload($textPayload)
+    {
+        return $this->call('newrelic_accept_distributed_trace_payload', array($textPayload));
+    }
+
+    /**
+     * Accept a distributed trace http safe payload.
+     *
+     * Generate an http safe payload using:
+     * $payload = newrelic_create_distributed_trace_payload();
+     * $httpSafePayload = $payload->httpSafe();
+     *
+     * @param string $httpSafePayload
+     *
+     * @return bool
+     */
+    public function acceptDistributedTracePayloadHttpSafe($httpSafePayload)
+    {
+        return $this->call('newrelic_accept_distributed_trace_payload_httpsafe', array($httpSafePayload));
+    }
+
+    /**
      * Call the named method with the given params.  Return false if the NewRelic PHP agent is not available.
      *
      * @param string $method

--- a/src/Newrelic.php
+++ b/src/Newrelic.php
@@ -57,9 +57,7 @@ class Newrelic
         }
 
         if ($handler === null) {
-            $handler = $this->installed
-                ? new DefaultHandler(function_exists('newrelic_create_distributed_trace_payload'))
-                : new NullHandler();
+            $handler = $this->installed ? new DefaultHandler(function_exists('newrelic_create_distributed_trace_payload')) : new NullHandler();
         }
 
         $this->handler = $handler;

--- a/tests/Handler/DefaultHandlerTest.php
+++ b/tests/Handler/DefaultHandlerTest.php
@@ -9,10 +9,11 @@ class DefaultHandlerTest extends TestCase
 {
     public function testImplementsInterface()
     {
-        $handler = new DefaultHandler();
+        $handler = new DefaultHandler(false);
 
         $this->assertInstanceOf('Intouch\Newrelic\Handler\Handler', $handler);
     }
+
     public function testHandleCallsFunctionWithArguments()
     {
         $functionName = 'strpos';
@@ -22,10 +23,24 @@ class DefaultHandlerTest extends TestCase
             0
         );
 
-        $handler = new DefaultHandler();
+        $handler = new DefaultHandler(false);
 
         $expected = call_user_func_array($functionName, $arguments);
 
         $this->assertSame($expected, $handler->handle($functionName, $arguments));
+    }
+
+    public function testIsDistributedTracingEnabled()
+    {
+        $handler = new DefaultHandler(true);
+
+        $this->assertTrue($handler->isDistributedTracingEnabled());
+    }
+
+    public function testIsDistributedTracingEnabledFalse()
+    {
+        $handler = new DefaultHandler(false);
+
+        $this->assertFalse($handler->isDistributedTracingEnabled());
     }
 }

--- a/tests/Handler/NullHandlerTest.php
+++ b/tests/Handler/NullHandlerTest.php
@@ -27,4 +27,11 @@ class NullHandlerTest extends TestCase
 
         $this->assertFalse($handler->handle($functionName, $arguments));
     }
+
+    public function testIsDistributedTracingEnabledReturnsFalse()
+    {
+        $handler = new NullHandler();
+
+        $this->assertFalse($handler->isDistributedTracingEnabled());
+    }
 }

--- a/tests/NewrelicTest.php
+++ b/tests/NewrelicTest.php
@@ -400,6 +400,57 @@ class NewrelicTest extends TestCase
         $this->assertSame($result, $agent->startTransaction($name, $licence));
     }
 
+    public function testCreateDistributedTracePayload()
+    {
+        $result = true;
+
+        $handler = $this->getHandlerSpy(
+            'newrelic_create_distributed_trace_payload',
+            array(),
+            $result
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertSame($result, $agent->createDistributedTracePayload());
+    }
+
+    public function testAcceptDistributedTracePayload()
+    {
+        $payload = 'payload';
+        $result = true;
+
+        $handler = $this->getHandlerSpy(
+            'newrelic_accept_distributed_trace_payload',
+            array(
+                $payload,
+            ),
+            $result
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertSame($result, $agent->acceptDistributedTracePayload($payload));
+    }
+
+    public function testAcceptDistributedTracePayloadHttpSafe()
+    {
+        $payload = 'payload';
+        $result = true;
+
+        $handler = $this->getHandlerSpy(
+            'newrelic_accept_distributed_trace_payload_httpsafe',
+            array(
+                $payload,
+            ),
+            $result
+        );
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertSame($result, $agent->acceptDistributedTracePayloadHttpSafe($payload));
+    }
+
     /**
      * @return bool
      */

--- a/tests/NewrelicTest.php
+++ b/tests/NewrelicTest.php
@@ -409,10 +409,25 @@ class NewrelicTest extends TestCase
             array(),
             $result
         );
+        $handler->expects($this->once())
+            ->method('isDistributedTracingEnabled')
+            ->willReturn(true);
 
         $agent = new Newrelic(false, $handler);
 
         $this->assertSame($result, $agent->createDistributedTracePayload());
+    }
+
+    public function testCreateDistributedTracePayloadNotEnabled()
+    {
+        $handler = $this->getHandlerMock();
+        $handler->expects($this->once())
+            ->method('isDistributedTracingEnabled')
+            ->willReturn(false);
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertFalse($agent->createDistributedTracePayload());
     }
 
     public function testAcceptDistributedTracePayload()
@@ -427,10 +442,27 @@ class NewrelicTest extends TestCase
             ),
             $result
         );
+        $handler->expects($this->once())
+            ->method('isDistributedTracingEnabled')
+            ->willReturn(true);
 
         $agent = new Newrelic(false, $handler);
 
         $this->assertSame($result, $agent->acceptDistributedTracePayload($payload));
+    }
+
+    public function testAcceptDistributedTracePayloadNotEnabled()
+    {
+        $payload = 'payload';
+
+        $handler = $this->getHandlerMock();
+        $handler->expects($this->once())
+            ->method('isDistributedTracingEnabled')
+            ->willReturn(false);
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertFalse($agent->acceptDistributedTracePayload($payload));
     }
 
     public function testAcceptDistributedTracePayloadHttpSafe()
@@ -445,10 +477,27 @@ class NewrelicTest extends TestCase
             ),
             $result
         );
+        $handler->expects($this->once())
+            ->method('isDistributedTracingEnabled')
+            ->willReturn(true);
 
         $agent = new Newrelic(false, $handler);
 
         $this->assertSame($result, $agent->acceptDistributedTracePayloadHttpSafe($payload));
+    }
+
+    public function testAcceptDistributedTracePayloadHttpSafeNotEnabled()
+    {
+        $payload = 'payload';
+
+        $handler = $this->getHandlerMock();
+        $handler->expects($this->once())
+            ->method('isDistributedTracingEnabled')
+            ->willReturn(false);
+
+        $agent = new Newrelic(false, $handler);
+
+        $this->assertFalse($agent->acceptDistributedTracePayloadHttpSafe($payload));
     }
 
     /**


### PR DESCRIPTION
https://docs.newrelic.com/docs/agents/php-agent/features/distributed-tracing-php-agent#manual

This pull request adds support for distributed tracing methods.

I had to add some feature detection to see if distributed tracing was available in `DefaultHandler`.

This comment says it should support Agent version 3.1+ and PHP 5.3+ (I noticed composer.json says we need `php >= 7.0.0`)
https://github.com/In-Touch/newrelic/blob/93d6565a5760f1d84255455a5b1dc4004c601ad0/src/Newrelic.php#L26